### PR TITLE
use cloudinary as default loader

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   // Target must be serverless
   target: "serverless",
+  images: {
+    loader: "cloudinary",
+    path: "https://res.cloudinary.com/rhnmht30/image/upload/",
+  },
 };
-


### PR DESCRIPTION
Specifying Cloudinary as default loader with path set to my unique URL provided with my Cloudinary account.